### PR TITLE
Firestore: Add support for Point-in-time-recovery (PITR)

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -140,6 +140,19 @@ properties:
       - :OPTIMISTIC_WITH_ENTITY_GROUPS
     default_from_api: true
   - !ruby/object:Api::Type::Enum
+    name: pointInTimeRecoveryEnablement
+    description: |
+      Whether to enable the PITR feature on this database.
+      When disabled allows reads against any version within the last hour.
+      When enabled allows reads against any version within the last last hour and 
+      reads against 1-minute snapshots beyond 1 hour and within 7 days.
+      `version_retention_period` and `earliest_version_time` can be used to determine the supported versions.
+    values:
+      - :POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED
+      - :POINT_IN_TIME_RECOVERY_ENABLED
+      - :POINT_IN_TIME_RECOVERY_DISABLED
+    default_from_api: true
+  - !ruby/object:Api::Type::Enum
     name: appEngineIntegrationMode
     description: |
       The App Engine integration mode to use for this database.
@@ -147,6 +160,21 @@ properties:
       - :ENABLED
       - :DISABLED
     default_from_api: true
+  - !ruby/object:Api::Type::String
+    name: version_retention_period
+    description: |
+      Output only. The period during which past versions of data are retained in the database.
+      Any read or query can specify a readTime within this window, and will read the state of the database at that time.
+      If the PITR feature is enabled, the retention period is 7 days. Otherwise, the retention period is 1 hour.
+      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+    output: true
+  - !ruby/object:Api::Type::String
+    name: earliest_version_time
+    description: |
+      Output only. The earliest timestamp at which older versions of the data can be read from the database. See [versionRetentionPeriod] above; this field is populated with now - versionRetentionPeriod.
+      This value is continuously updated, and becomes stale the moment it is queried. If you are using this value to recover data, make sure to account for the time from the moment when the value is queried to the moment when you initiate the recovery.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+    output: true
   - !ruby/object:Api::Type::String
     name: key_prefix
     description: |

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -27,5 +27,7 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   concurrency_mode            = "OPTIMISTIC"
   app_engine_integration_mode = "DISABLED"
 
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+
   depends_on = [google_project_service.firestore]
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for Firestore Point-in-time-recovery (PITR).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `point_in_time_recovery_enablement`, `version_retention_period`, and `earliest_version_time` fields to `google_firestore_database ` resource
```
